### PR TITLE
Fix ulimit -n of bench -workermode started via systemd

### DIFF
--- a/provisioning/roles/prepare_bench/files/torb.bench.service
+++ b/provisioning/roles/prepare_bench/files/torb.bench.service
@@ -4,6 +4,7 @@ Description = isucon8 qualifier bench worker
 [Service]
 WorkingDirectory=/home/isucon/torb/bench
 EnvironmentFile=/home/isucon/torb/webapp/env.sh
+LimitNOFILE=655360
 
 ExecStart = /home/isucon/torb/bench/bin/bench -workermode -portal http://127.0.0.1
 


### PR DESCRIPTION
[provisioning/roles/increase_ulimit](https://github.com/isucon/isucon8-qualify/blob/9eca9ce43f15ade2f085870a32b7067f26c1fe87/provisioning/roles/increase_ulimit/tasks/main.yml) configures ulimit -n at `/etc/security/limits.d`. But, it does not affect systemd. ref. https://support.hpe.com/hpsc/doc/public/display?docId=mmr_kc-0128457

This PR fixes that ulimit -n of `bench -workermode` started via systemd.

-----
This issue was reported during the extra game.

Fortunately, it looks `too many open files` error occurs only after webapp marks very high score like more than 100,000. I remember that I did not observe `too many open files` errors during the ISUCON contest.